### PR TITLE
Eliminate all allocations in parser

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -19,6 +19,7 @@ import Data.Primitive.ByteArray
 import Control.Applicative (ZipList(..))
 import qualified Data.Bytes as Bytes
 import qualified Url
+import qualified Url.Unsafe
 import qualified Data.ByteString.Char8 as BS
 import qualified URI.ByteString as URI
 
@@ -42,8 +43,8 @@ instance NFData Url.ParseError
 instance NFData ByteArray where
   rnf !b = b `seq` ()
 instance NFData Bytes
-instance NFData Url.Url where
-  rnf (Url.Url a b c d e f g h i) = rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf e `seq` rnf f `seq` rnf g `seq` rnf h `seq` rnf i
+instance NFData Url.Unsafe.Url where
+  rnf (Url.Unsafe.Url a _ _ _ _ _ _ _ _) = rnf a
 
 main :: IO ()
 main = defaultMain

--- a/cabal.project
+++ b/cabal.project
@@ -3,5 +3,4 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/byteverse/bytesmith
-    tag: 2522d5b59e7bc684410176d9bea2309812ed7d40
-
+    tag: 37796446698354d0e310b4668c404437f34a1e29

--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/byteverse/bytesmith
-    tag: 37796446698354d0e310b4668c404437f34a1e29
+    tag: d25a41304f83bc95dce89eebe800b4209ae8321a

--- a/src/Url.hs
+++ b/src/Url.hs
@@ -14,7 +14,7 @@
 -- | Note: this library parses, but does not validate urls
 module Url 
   ( -- * Types
-    Url(..)
+    Url
   , ParseError(..)
     -- * Parsing
   , decodeUrl
@@ -33,83 +33,59 @@ import Control.Monad ((<$!>))
 import Data.Char (ord)
 import Data.Word (Word8, Word32, Word16)
 import Data.Bytes.Types (Bytes(..))
+import Url.Rebind (parserUrl)
+import Url.Unsafe (Url(..),ParseError(..))
+import GHC.Exts (Int(I#))
 import qualified Data.Bytes as Bytes
 import qualified Data.Bytes.Parser as P
 import qualified Data.Bytes.Parser.Latin as P (skipUntil, char2, decWord16)
 import qualified Data.Bytes.Parser.Unsafe as PU
 
--- | Url type represented by its serialization,
--- and slices of that serialization.
-{- | Syntax in pseudo-BNF:
-
-@
-url = scheme ":" [ hierarchical | non-hierarchical ] [ "?" query ]? [ "#" fragment ]?
-non-hierarchical = non-hierarchical-path
-non-hierarchical-path = /* Does not start with "/" */
-hierarchical = authority? hierarchical-path
-authority = "//" userinfo? host [ ":" port ]?
-userinfo = username [ ":" password ]? "@"
-hierarchical-path = [ "/" path-segment ]+
-@
--}
-data Url = Url
-  { urlSerialization :: !Bytes
-  -- Components
-  , urlSchemeEnd     :: !Word32 -- ^ Before @\':'@
-  , urlUsernameEnd   :: !Word32 -- ^ Before @\':'@ (if a password is given) or @\'\@'@ (if not)
-  , urlHostStart     :: !Word32
-  , urlHostEnd       :: !Word32
-  , urlPort          :: !(Maybe Word16)
-  , urlPathStart     :: !Word32 -- ^ Before initial @\'/'@, if any
-  , urlQueryStart    :: !Word32 -- ^ Before @\'?'@
-  , urlFragmentStart :: !Word32 -- ^ Before @\'#'@
-  } deriving (Eq, Ord, Show)
-
 -- | Slice into the 'Url' and retrieve the scheme, if it's present
 getScheme :: Url -> Maybe Bytes
 getScheme Url{urlSerialization,urlSchemeEnd} = 
-  if urlSchemeEnd == 0
+  if I# urlSchemeEnd == 0
     then Nothing
-    else Just $ Bytes.unsafeTake (fromIntegral urlSchemeEnd) urlSerialization
+    else Just $ Bytes.unsafeTake (I# urlSchemeEnd) urlSerialization
 
 -- | Slice into the 'Url' and retrieve the username, if it's present
 getUsername :: Url -> Maybe Bytes
 getUsername Url{urlSerialization,urlSchemeEnd,urlUsernameEnd,urlHostStart} =
-  if urlUsernameEnd == urlHostStart
+  if I# urlUsernameEnd == I# urlHostStart
     then Nothing
-    else Just $ unsafeSlice (urlSchemeEnd + 3) urlUsernameEnd urlSerialization
+    else Just $ unsafeSlice (I# urlSchemeEnd + 3) (I# urlUsernameEnd) urlSerialization
 
 -- | Slice into the 'Url' and retrieve the host, if it's present
 getHost :: Url -> Maybe Bytes
 getHost Url{urlSerialization,urlHostStart,urlHostEnd} =
-  if urlHostStart == urlHostEnd
+  if I# urlHostStart == I# urlHostEnd
     then Nothing
-    else Just $ unsafeSlice urlHostStart urlHostEnd urlSerialization
+    else Just $ unsafeSlice (I# urlHostStart) (I# urlHostEnd) urlSerialization
 
 -- | Slice into the 'Url' and retrieve the path starting with @\'/'@, if it's present
 getPath :: Url -> Maybe Bytes
 getPath Url{urlSerialization,urlPathStart,urlQueryStart} = 
-  if fromIntegral urlPathStart == len
+  if I# urlPathStart == len
     then Nothing
-    else Just $ unsafeSlice urlPathStart urlQueryStart urlSerialization
+    else Just $ unsafeSlice (I# urlPathStart) (I# urlQueryStart) urlSerialization
   where
   len = Bytes.length urlSerialization
 
 -- | Slice into the 'Url' and retrieve the query string starting with @\'?'@, if it's present
 getQuery :: Url -> Maybe Bytes
 getQuery Url{urlSerialization,urlQueryStart,urlFragmentStart} =
-  if len == fromIntegral urlQueryStart
+  if len == I# urlQueryStart
     then Nothing
-    else Just $ unsafeSlice urlQueryStart urlFragmentStart urlSerialization
+    else Just $ unsafeSlice (I# urlQueryStart) (I# urlFragmentStart) urlSerialization
   where
   len = Bytes.length urlSerialization
 
 -- | Slice into the 'Url' and retrieve the fragment starting with @\'#'@, if it's present
 getFragment :: Url -> Maybe Bytes
 getFragment Url{urlSerialization,urlFragmentStart} =
-  if len == fromIntegral urlFragmentStart
+  if len == I# urlFragmentStart
     then Nothing
-    else Just $ unsafeSlice urlFragmentStart (fromIntegral len) urlSerialization
+    else Just $ unsafeSlice (I# urlFragmentStart) len urlSerialization
   where
   len = Bytes.length urlSerialization
 
@@ -142,103 +118,18 @@ until_ p m = go
       then return ()
       else go
 
--- | Possible parse errors
-data ParseError
-  = EndOfInput
-  | InvalidAuthority
-  | InvalidPort
-  deriving (Eq, Ord, Show)
-
 -- | Decode a hierarchical URL
 decodeUrl :: Bytes -> Either ParseError Url
 decodeUrl urlSerialization = P.parseBytesEither (parserUrl urlSerialization) urlSerialization
-
--- | Parser type from @bytesmith@
--- Note: non-hierarchical Urls (such as relative paths) will not currently parse.
-parserUrl :: Bytes -> P.Parser ParseError s Url
-parserUrl urlSerialization = do
-  -- TODO: use skipTrailedByEither later
-  (!i1, !colonFirst) <- P.measure $ 
-               P.skipTrailedByEither EndOfInput (c2w ':') (c2w '/')
-    `P.orElse` pure False
-  !urlSchemeEnd <-
-    if colonFirst
-      then do
-        P.char2 InvalidAuthority '/' '/'
-        pure $ fromIntegral $! i1 - 1
-      else do
-        PU.jump 0
-        pure 0
-  !userStart <- PU.cursor
-  (!i3, _) <- P.measure $ P.skipUntil ':'
-  PU.unconsume i3
-  (!i4, _) <- P.measure $ P.skipUntil '@'
-  PU.unconsume i4
-  (!i5, _) <- P.measure $ P.skipUntil '/'
-  PU.unconsume i5
-  !urlUsernameEnd <- fromIntegral <$!> do
-    if i4 >= i5 || i3 == i4
-      then do
-        PU.jump (userStart)
-        pure (userStart)
-      else do
-        let jumpi = i4 
-        if i3 < i4
-          then do
-            PU.jump (userStart + jumpi + 1)
-            pure (userStart + i3)
-          else do
-            PU.jump (userStart + jumpi + 1)
-            pure (userStart + i4)
-  !urlHostStart' <- PU.cursor
-  let !urlHostStart = fromIntegral urlHostStart'
-  (!i6, !colonFirst2) <- P.measure $ 
-               P.skipTrailedByEither EndOfInput (c2w ':') (c2w '/')
-    `P.orElse` pure False
-  (!urlHostEnd, !urlPort) <- 
-    if colonFirst2
-      then do
-        urlHostEnd' <- fromIntegral <$!> PU.cursor
-        murlPort' <- Just <$!> P.decWord16 InvalidPort
-        pure (urlHostEnd' - 1, murlPort')
-      else do
-        PU.jump (urlHostStart' + i6 - 1)
-        urlHostEnd' <- fromIntegral <$!> PU.cursor
-        pure (urlHostEnd', Nothing)
-  !urlPathStart <- fromIntegral <$!> PU.cursor
-  (!i8, _) <- P.measure $ P.skipUntil '?'
-  PU.unconsume i8
-  (!i9, _) <- P.measure $ P.skipUntil '#'
-  PU.unconsume i9
-  let !len = fromIntegral $ Bytes.length urlSerialization
-  WordPair !urlQueryStart !urlFragmentStart <- case compare i8 i9 of
-    EQ -> pure $! WordPair len len
-    LT -> do
-      P.skipUntil '#'
-      !eoi <- P.isEndOfInput
-      let !urlFragmentStart' = 
-            if eoi
-              then len
-              else fromIntegral i9 + urlPathStart
-      pure $! WordPair (fromIntegral i8 + urlPathStart) urlFragmentStart'
-    GT -> do
-      P.skipUntil '#'
-      !eoi <- P.isEndOfInput
-      let !urlFragmentStart' = 
-            if eoi
-              then len
-              else fromIntegral i9 + urlPathStart
-      pure $! WordPair urlFragmentStart' urlFragmentStart'
-  pure $ Url {..}
 
 data WordPair = WordPair 
   {-# UNPACK #-} !Word32
   {-# UNPACK #-} !Word32
 
 {-# INLINE unsafeSlice #-}
-unsafeSlice :: Word32 -> Word32 -> Bytes -> Bytes
+unsafeSlice :: Int -> Int -> Bytes -> Bytes
 unsafeSlice begin end (Bytes arr off _) = 
-  Bytes arr (off + fromIntegral begin) (fromIntegral $ end - begin)
+  Bytes arr (off + begin) (end - begin)
 
 -- | Unsafe conversion between 'Char' and 'Word8'. This is a no-op and
 -- silently truncates to 8 bits Chars > '\255'. It is provided as

--- a/src/Url/Rebind.hs
+++ b/src/Url/Rebind.hs
@@ -34,12 +34,14 @@ import qualified GHC.Exts as Exts
 
 -- | Decode a hierarchical URL
 decodeUrl :: Bytes -> Either ParseError Url
-decodeUrl urlSerialization = P.parseBytesEither (parserUrl urlSerialization) urlSerialization
+decodeUrl urlSerialization = P.parseBytesEither parserUrl urlSerialization
 
 -- | Parser type from @bytesmith@
 -- Note: non-hierarchical Urls (such as relative paths) will not currently parse.
-parserUrl :: Bytes -> P.Parser ParseError s Url
-parserUrl urlSerialization@(Bytes _ _ (I# len)) = 
+parserUrl :: P.Parser ParseError s Url
+parserUrl = 
+  P.peekRemaining 
+  >>= \urlSerialization@(Bytes _ _ (I# len)) ->
   PU.cursor#
   >>= \start ->
   P.measure

--- a/src/Url/Rebind.hs
+++ b/src/Url/Rebind.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE
+    OverloadedStrings
+  , BangPatterns
+  , UnboxedTuples
+  , UnboxedSums
+  , MagicHash
+  , RebindableSyntax
+  , ScopedTypeVariables
+  , LambdaCase
+  , RecordWildCards
+  , NamedFieldPuns
+  , ApplicativeDo
+#-}
+
+-- The parser lives in its own module because it uses RebindableSyntax,
+-- which adversely affects inference and error messages.
+module Url.Rebind
+  ( parserUrl
+  ) where
+
+import Prelude hiding ((>>=),(>>),pure)
+import Data.Bytes.Parser.Rebindable ((>>),(>>=),pure)
+
+import Url.Unsafe (Url(..),ParseError(..))
+import Data.Char (ord)
+import Data.Word (Word8)
+import Data.Bytes.Types (Bytes(..))
+import GHC.Exts (Int(I#),Int#,Word#,(+#),(<#),(-#),orI#,(>=#),(==#),(>#))
+import GHC.Word (Word(W#),Word16(W16#))
+import qualified Data.Bytes as Bytes
+import qualified Data.Bytes.Parser as P
+import qualified Data.Bytes.Parser.Latin as P (skipUntil, char2, decWord16)
+import qualified Data.Bytes.Parser.Unsafe as PU
+import qualified GHC.Exts as Exts
+
+-- | Parser type from @bytesmith@
+-- Note: non-hierarchical Urls (such as relative paths) will not currently parse.
+parserUrl :: Bytes -> P.Parser ParseError s Url
+parserUrl urlSerialization = let !(I# len) = Bytes.length urlSerialization in
+  -- TODO: use skipTrailedByEither later
+  P.measure
+    ( P.skipTrailedBy2 EndOfInput (c2w ':') (c2w '/')
+      `P.orElse`
+      pure False
+    )
+  >>= \(I# i1, !colonFirst) ->
+    ( case colonFirst of
+        False ->
+          P.char2 InvalidAuthority '/' '/' >> pure (i1 -# 1# )
+        True ->
+          -- Jump to position zero is unsound!!!
+          PU.jump 0 >> pure 0#
+    )
+  >>= \urlSchemeEnd -> PU.cursor#
+  >>= \userStart -> P.measure_# (P.skipUntil ':')
+  >>= \i3 -> PU.unconsume (I# i3)
+  >>  P.measure_# (P.skipUntil '@')
+  >>= \i4 -> PU.unconsume (I# i4)
+  >>  P.measure_# (P.skipUntil '/')
+  >>= \i5 -> PU.unconsume (I# i5)
+  >>  ( case (i4 >=# i5) `orI#` (i3 ==# i4) of
+          1# -> PU.jump (I# userStart) >> pure userStart
+          _ -> let jumpi = i4 in
+            case i3 <# i4 of
+              1# -> PU.jump (I# (userStart +# jumpi +# 1# )) >> pure (userStart +# i3)
+              _ -> PU.jump (I# (userStart +# jumpi +# 1# )) >> pure (userStart +# i4)
+      )
+  >>= \urlUsernameEnd -> PU.cursor#
+  >>= \urlHostStart ->
+    ( P.skipTrailedBy2# EndOfInput (c2w ':') (c2w '/')
+      -- Why was this orElse here? When it is commented out,
+      -- all tests still pass.
+      -- `P.orElse`
+      -- pure False
+    )
+  >>= \colonFirst2 ->
+    ( case colonFirst2 of
+        0# -> PU.cursor#
+          >>= \urlHostEnd -> P.decWord16 InvalidPort
+          >>= \(W16# urlPort) ->
+          pure (# urlHostEnd -# 1#, Exts.word2Int# urlPort #)
+        _ -> -- PU.jump (I# ((urlHostStart +# i6) -# 1# ))
+              PU.cursor#
+          >>= \urlHostEnd' ->
+              -- Backing up by one since we want to put the slash back
+              -- to let it be part of the path.
+              let urlHostEnd = urlHostEnd' -# 1# in
+              PU.jump (I# urlHostEnd)
+          >>  pure (# urlHostEnd, 0x10000# #)
+    )
+  >>= \(# !urlHostEnd, !urlPort #) -> PU.cursor#
+  >>= \urlPathStart -> P.measure_# (P.skipUntil '?')
+  >>= \i8 -> PU.unconsume (I# i8)
+  >>  P.measure_# (P.skipUntil '#')
+  >>= \i9 -> PU.unconsume (I# i9)
+  >>  ( case intCompare# i8 i9 of
+          EQ -> pure (# len, len #)
+          LT -> P.skipUntil '#'
+            >>  P.isEndOfInput
+            >>= \eoi -> 
+            let !urlFragmentStart = case eoi of
+                  True -> len
+                  False -> i9 +# urlPathStart
+             in pure (# (i8 +# urlPathStart), urlFragmentStart #)
+          GT -> P.skipUntil '#'
+            >>  P.isEndOfInput
+            >>= \eoi ->
+            let !urlFragmentStart = case eoi of
+                  True -> len
+                  False -> i9 +# urlPathStart
+             in pure (# urlFragmentStart, urlFragmentStart #)
+      )
+  >>= \(# !urlQueryStart, !urlFragmentStart #) ->
+  pure (Url {..})
+
+intCompare# :: Int# -> Int# -> Ordering
+intCompare# a b = case a ==# b of
+  0# -> case a ># b of
+    0# -> LT
+    _ -> GT
+  _ -> EQ
+
+-- | Unsafe conversion between 'Char' and 'Word8'. This is a no-op and
+-- silently truncates to 8 bits Chars > '\255'. It is provided as
+-- convenience for ByteString construction.
+c2w :: Char -> Word8
+c2w = fromIntegral . ord
+{-# INLINE c2w #-}
+

--- a/src/Url/Unsafe.hs
+++ b/src/Url/Unsafe.hs
@@ -19,15 +19,8 @@ module Url.Unsafe
   , ParseError(..)
   ) where
 
-import Control.Monad ((<$!>))
-import Data.Char (ord)
-import Data.Word (Word8, Word32, Word16)
 import Data.Bytes.Types (Bytes(..))
-import GHC.Exts (Int#,Word#)
-import qualified Data.Bytes as Bytes
-import qualified Data.Bytes.Parser as P
-import qualified Data.Bytes.Parser.Latin as P (skipUntil, char2, decWord16)
-import qualified Data.Bytes.Parser.Unsafe as PU
+import GHC.Exts (Int#)
 
 -- | Url type represented by its serialization,
 -- and slices of that serialization.

--- a/src/Url/Unsafe.hs
+++ b/src/Url/Unsafe.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE
+    OverloadedStrings
+  , BangPatterns
+  , UnboxedTuples
+  , UnboxedSums
+  , MagicHash
+  , ScopedTypeVariables
+  , LambdaCase
+  , RecordWildCards
+  , NamedFieldPuns
+  , ApplicativeDo
+#-}
+
+{-# OPTIONS_HADDOCK not-home #-}
+
+module Url.Unsafe
+  ( -- * Types
+    Url(..)
+  , ParseError(..)
+  ) where
+
+import Control.Monad ((<$!>))
+import Data.Char (ord)
+import Data.Word (Word8, Word32, Word16)
+import Data.Bytes.Types (Bytes(..))
+import GHC.Exts (Int#,Word#)
+import qualified Data.Bytes as Bytes
+import qualified Data.Bytes.Parser as P
+import qualified Data.Bytes.Parser.Latin as P (skipUntil, char2, decWord16)
+import qualified Data.Bytes.Parser.Unsafe as PU
+
+-- | Url type represented by its serialization,
+-- and slices of that serialization.
+{- | Syntax in pseudo-BNF:
+
+@
+url = scheme ":" [ hierarchical | non-hierarchical ] [ "?" query ]? [ "#" fragment ]?
+non-hierarchical = non-hierarchical-path
+non-hierarchical-path = /* Does not start with "/" */
+hierarchical = authority? hierarchical-path
+authority = "//" userinfo? host [ ":" port ]?
+userinfo = username [ ":" password ]? "@"
+hierarchical-path = [ "/" path-segment ]+
+@
+-}
+data Url = Url
+  { urlSerialization :: {-# UNPACK #-} !Bytes
+  -- Components
+  , urlSchemeEnd     :: !Int# -- ^ Before @\':'@
+  , urlUsernameEnd   :: !Int# -- ^ Before @\':'@ (if a password is given) or @\'\@'@ (if not)
+  , urlHostStart     :: !Int#
+  , urlHostEnd       :: !Int#
+  , urlPort          :: !Int#
+  , urlPathStart     :: !Int# -- ^ Before initial @\'/'@, if any
+  , urlQueryStart    :: !Int# -- ^ Before @\'?'@
+  , urlFragmentStart :: !Int# -- ^ Before @\'#'@
+  } deriving (Eq, Ord, Show)
+
+-- | Possible parse errors
+data ParseError
+  = EndOfInput
+  | InvalidAuthority
+  | InvalidPort
+  deriving (Eq, Ord, Show)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,9 +1,12 @@
+{-# language MagicHash #-}
+
 module Main where
 
 import Data.Bytes
 import Test.Tasty
 import Test.Tasty.HUnit
 import Url
+import Url.Unsafe
 
 main :: IO ()
 main = defaultMain tests
@@ -53,14 +56,14 @@ urlBytes1 = fromAsciiString "https://google.com/foo?bar=qux#quine"
 url1 :: Url
 url1 = Url
   { urlSerialization = urlBytes1
-  , urlSchemeEnd     = 5
-  , urlUsernameEnd   = 8
-  , urlHostStart     = 8
-  , urlHostEnd       = 18
-  , urlPort          = Nothing
-  , urlPathStart     = 18
-  , urlQueryStart    = 22
-  , urlFragmentStart = 30
+  , urlSchemeEnd     = 5#
+  , urlUsernameEnd   = 8#
+  , urlHostStart     = 8#
+  , urlHostEnd       = 18#
+  , urlPort          = 0x10000#
+  , urlPathStart     = 18#
+  , urlQueryStart    = 22#
+  , urlFragmentStart = 30#
   }
 
 urlBytes2 :: Bytes
@@ -69,14 +72,14 @@ urlBytes2 = fromAsciiString "http://user:password@facebook.org:322/"
 url2 :: Url
 url2 = Url
   { urlSerialization = urlBytes2
-  , urlSchemeEnd     = 4
-  , urlUsernameEnd   = 11
-  , urlHostStart     = 21
-  , urlHostEnd       = 33
-  , urlPort          = Just 322
-  , urlPathStart     = 37
-  , urlQueryStart    = 38
-  , urlFragmentStart = 38
+  , urlSchemeEnd     = 4#
+  , urlUsernameEnd   = 11#
+  , urlHostStart     = 21#
+  , urlHostEnd       = 33#
+  , urlPort          = 322#
+  , urlPathStart     = 37#
+  , urlQueryStart    = 38#
+  , urlFragmentStart = 38#
   }
 
 urlBytes3 :: Bytes
@@ -85,12 +88,12 @@ urlBytes3 = fromAsciiString "x@g/f/:/@?#"
 url3 :: Url
 url3 = Url
   { urlSerialization = urlBytes3
-  , urlSchemeEnd = 0
-  , urlUsernameEnd = 1
-  , urlHostStart = 2
-  , urlHostEnd = 3
-  , urlPort = Nothing
-  , urlPathStart = 3
-  , urlQueryStart = 9
-  , urlFragmentStart = 10
+  , urlSchemeEnd = 0#
+  , urlUsernameEnd = 1#
+  , urlHostStart = 2#
+  , urlHostEnd = 3#
+  , urlPort = 0x10000#
+  , urlPathStart = 3#
+  , urlQueryStart = 9#
+  , urlFragmentStart = 10#
   }

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -45,6 +45,10 @@ unitTests = testGroup "Unit tests"
   , testCase "getExtension" $
           getExtension (unwrap $ decodeUrl $ fromAsciiString "https://imgur.com/./f.o.o.png?bar=bar#q") 
       @?= Just (fromAsciiString "png")
+  , testCase "offsetUrl" $ do
+      let urlBytes1Offset = unsafeDrop 2 $ fromAsciiString "  " <> urlBytes1
+          Right url1Offset = decodeUrl urlBytes1Offset
+      getPath url1 @?= getPath url1Offset
   ]
 
 unwrap :: Either a b -> b

--- a/url-bytes.cabal
+++ b/url-bytes.cabal
@@ -17,7 +17,9 @@ library
   ghc-options: -Wall -O2
   exposed-modules: 
       Url
-  -- other-modules:
+      Url.Unsafe
+  other-modules:
+      Url.Rebind
   -- other-extensions:
   build-depends: 
       base ^>=4.13.0.0


### PR DESCRIPTION
Do not merge this. There is still some cleanup that needs to happen. This makes several changes:

* All fields in the `Url` data types are changed from `Word32` to `Int#`. This avoids some narrowing that was previously happening.
* The parser is moved into its own module (`Url.Rebind`) where nonstandard `>>=`, `>>`, and `pure` and imported from `Data.Bytes.Parser.Rebindable`. Unfortunately, `RebindableSyntax` does not actually work with a levity-polymorphic bind, so I desugared `do` manually.
* The data type `Url` is moved into `Url.Unsafe`. This had to be moved somewhere since `Url` imports `Url.Rebind`, and I didn't want to put it in `Url.Rebind`.
* Everything except for the `Url` data constructor is still exported from `Url`.

Manual inspection of the optimized core shows that the parser no longer allocates anything on the heap other than the resulting `Url`.

Before:

```
benchmarked url-bytes 1000
time                 227.0 μs   (224.9 μs .. 229.3 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 225.7 μs   (225.0 μs .. 226.9 μs)
std dev              2.910 μs   (2.147 μs .. 4.161 μs)
```

After:

```
benchmarked url-bytes 1000
time                 178.4 μs   (176.8 μs .. 180.5 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 178.1 μs   (177.4 μs .. 178.8 μs)
std dev              2.417 μs   (1.956 μs .. 2.969 μs)
```