### PR TITLE
Add test, remove cabal.project file

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,0 @@
-packages: .

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -67,6 +67,16 @@ unitTests = testGroup "Unit tests"
   , testCase "constructUrl" $ do
       url1TH1 @?= url1
       url1TH2 @?= url1
+  , testCase "URL decoding 5, path" $ case decodeUrl urlBytes5 of
+      Left{} -> assertFailure "could not decode url 5"
+      Right u -> case getPath u of
+        Nothing -> assertFailure "url 5 missing path"
+        Just p -> fromAsciiString "/resource" @?= p
+  , testCase "URL decoding 6, path" $ case decodeUrl urlBytes5 of
+      Left{} -> assertFailure "could not decode url 6"
+      Right u -> case getPath u of
+        Nothing -> assertFailure "url 6 missing path"
+        Just p -> fromAsciiString "/resource" @?= p
   ]
 
 unwrap :: Either a b -> b
@@ -129,3 +139,8 @@ url3 = Url
 urlBytes4 :: Bytes
 urlBytes4 = fromAsciiString "file+udp:bar.txt"
 
+urlBytes5 :: Bytes
+urlBytes5 = fromAsciiString "http://example.com/resource?foo=bar"
+
+urlBytes6 :: Bytes
+urlBytes6 = fromAsciiString "example.com/resource?foo=bar"

--- a/url-bytes.cabal
+++ b/url-bytes.cabal
@@ -25,7 +25,7 @@ library
       base >=4.12.0.0 && <5
     , byteslice >=0.2.1 && <0.3
     , primitive >= 0.7.1 && < 0.8
-    , bytesmith >=0.3.6 && <0.4
+    , bytesmith >=0.3.7 && <0.4
     , template-haskell >=2.14.0.0 && <2.17.0.0
   hs-source-dirs: src
   default-language: Haskell2010


### PR DESCRIPTION
Adds a simple test that passes. I was looking for what was causing an issue in another project and ruled out the parser itself with this test.